### PR TITLE
Add support for modern versions of phpunit/php-code-coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "peridot-php/peridot": "^1",
-    "phpunit/php-code-coverage": "^4|^5"
+    "phpunit/php-code-coverage": "^6|^7"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Code coverage 4 allowed PHP 5.6, 5 allowed PHP 7.0, both of which are no longer supported.